### PR TITLE
Add package.json#exports

### DIFF
--- a/packages/click-to-react-component/package.json
+++ b/packages/click-to-react-component/package.json
@@ -3,6 +3,7 @@
   "name": "click-to-react-component",
   "version": "1.0.3",
   "description": "Option+Click your React components in your browser to open the source file in VS Code",
+  "exports": "./index.js",
   "types": "types.d.ts",
   "scripts": {
     "build": "echo \"Fuck build tools\"",


### PR DESCRIPTION
```
❯ pnpm dev

> next-app@ dev /private/tmp/next-app
> next dev

ready - started server on 0.0.0.0:3000, url: http://localhost:3000
wait  - compiling...
event - compiled client and server successfully in 976 ms (148 modules)
wait  - compiling / (client and server)...
wait  - compiling...
event - compiled client and server successfully in 395 ms (166 modules)
(node:14038) [DEP0151] DeprecationWarning: No "main" or "exports" field defined in the package.json for /private/tmp/next-app/node_modules/click-to-react-component/ resolving the main entry point "index.js", imported from /private/tmp/next-app/.next/server/pages/_app.js.
Default "index" lookups for the main are deprecated for ES modules.
(Use `node --trace-deprecation ...` to show where the warning was created)
```