### PR TITLE
Make getPathToSource configurable as a prop

### DIFF
--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -8,7 +8,7 @@ import { html } from 'htm/react'
 import * as React from 'react'
 
 import { ContextMenu } from './ContextMenu.js'
-import { getPathToSource } from './getPathToSource.js'
+import { getPathToSource as defaultGetPathToSource } from './getPathToSource.js'
 import { getSourceForElement } from './getSourceForElement.js'
 
 export const State = /** @type {const} */ ({
@@ -20,7 +20,7 @@ export const State = /** @type {const} */ ({
 /**
  * @param {Props} props
  */
-export function ClickToComponent({ editor = 'vscode' }) {
+export function ClickToComponent({ editor = 'vscode', getPathToSource = defaultGetPathToSource }) {
   const [state, setState] = React.useState(
     /** @type {State[keyof State]} */
     (State.IDLE)
@@ -49,7 +49,7 @@ export function ClickToComponent({ editor = 'vscode' }) {
         setState(State.IDLE)
       }
     },
-    [editor, state, target]
+    [editor, state, target, getPathToSource]
   )
 
   const onClose = React.useCallback(
@@ -205,6 +205,7 @@ export function ClickToComponent({ editor = 'vscode' }) {
     <${FloatingPortal} key="click-to-component-portal">
       ${html`<${ContextMenu}
         key="click-to-component-contextmenu"
+        getPathToSource=${getPathToSource}
         onClose=${onClose}
       />`}
     </${FloatingPortal}

--- a/packages/click-to-react-component/src/ContextMenu.js
+++ b/packages/click-to-react-component/src/ContextMenu.js
@@ -24,7 +24,6 @@ import * as React from 'react'
 import mergeRefs from 'react-merge-refs'
 
 import { getDisplayNameForInstance } from './getDisplayNameFromReactInstance.js'
-import { getPathToSource } from './getPathToSource.js'
 import { getPropsForInstance } from './getPropsForInstance.js'
 import { getReactInstancesForElement } from './getReactInstancesForElement.js'
 import { getSourceForInstance } from './getSourceForInstance.js'
@@ -35,7 +34,7 @@ export const ContextMenu = React.forwardRef(
     props,
     ref
   ) => {
-    const { onClose } = props
+    const { getPathToSource, onClose } = props
 
     const [target, setTarget] = React.useState(
       /** @type {HTMLElement | null} */

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -1,9 +1,12 @@
+import { Source as ReactReconcilerSource } from 'react-reconciler'
+
 export { ClickToComponent } from './src/ClickToComponent'
 
 export type Editor = 'vscode' | 'vscode-insiders'
 
 export type ClickToComponentProps = {
   editor?: Editor
+  getPathToSource?: (source: ReactReconcilerSource) => string
 }
 
 export type Coords = [MouseEvent['pageX'], MouseEvent['pageY']]


### PR DESCRIPTION
We have a use case in which some of our React components are actually morphed from another file type. By exposing that prop we can replace the file name and open the real source instead.

Thanks for making this component! It's super handy. :)