### PR TITLE
Support for onOpenComponent callback

### DIFF
--- a/.changeset/thirty-points-pretend.md
+++ b/.changeset/thirty-points-pretend.md
@@ -1,0 +1,5 @@
+---
+'click-to-react-component': minor
+---
+
+Added onOpenFile prop

--- a/.changeset/thirty-points-pretend.md
+++ b/.changeset/thirty-points-pretend.md
@@ -2,4 +2,4 @@
 'click-to-react-component': minor
 ---
 
-Added onOpenFile prop
+Added onOpenComponent prop

--- a/packages/click-to-react-component/README.md
+++ b/packages/click-to-react-component/README.md
@@ -138,6 +138,15 @@ If, like me, you use [`vscode-insiders`](https://code.visualstudio.com/insiders/
 +<ClickToComponent editor="vscode-insiders" />
 ```
 
+### `onOpenFile`
+
+If set, the callback will be invoked instead of opening the editor.
+
+```diff
+-<ClickToComponent />
++<ClickToComponent onOpenFile={alert} />
+```
+
 ## Run Locally
 
 Clone the project

--- a/packages/click-to-react-component/README.md
+++ b/packages/click-to-react-component/README.md
@@ -138,13 +138,13 @@ If, like me, you use [`vscode-insiders`](https://code.visualstudio.com/insiders/
 +<ClickToComponent editor="vscode-insiders" />
 ```
 
-### `onOpenFile`
+### `onOpenComponent`
 
 If set, the callback will be invoked instead of opening the editor.
 
 ```diff
 -<ClickToComponent />
-+<ClickToComponent onOpenFile={alert} />
++<ClickToComponent onOpenComponent={(source) => alert(source.fileName)} />
 ```
 
 ## Run Locally

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -20,7 +20,7 @@ export const State = /** @type {const} */ ({
 /**
  * @param {Props} props
  */
-export function ClickToComponent({ editor = 'vscode', onOpenFile }) {
+export function ClickToComponent({ editor = 'vscode', onOpenComponent }) {
   const [state, setState] = React.useState(
     /** @type {State[keyof State]} */
     (State.IDLE)
@@ -39,21 +39,21 @@ export function ClickToComponent({ editor = 'vscode', onOpenFile }) {
       event
     ) {
       if (state === State.HOVER && target instanceof HTMLElement) {
-        const source = getSourceForElement(target)
-        const path = getPathToSource(source)
-        const url = `${editor}://file/${path}`
-
         event.preventDefault()
-        if (onOpenFile) {
-          onOpenFile(path)
+
+        const source = getSourceForElement(target)
+        if (onOpenComponent) {
+          onOpenComponent(source)
         } else {
+          const path = getPathToSource(source)
+          const url = `${editor}://file/${path}`
           window.open(url)
         }
 
         setState(State.IDLE)
       }
     },
-    [editor, onOpenFile, state, target]
+    [editor, onOpenComponent, state, target]
   )
 
   const onClose = React.useCallback(

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -20,7 +20,7 @@ export const State = /** @type {const} */ ({
 /**
  * @param {Props} props
  */
-export function ClickToComponent({ editor = 'vscode' }) {
+export function ClickToComponent({ editor = 'vscode', onOpenFile }) {
   const [state, setState] = React.useState(
     /** @type {State[keyof State]} */
     (State.IDLE)
@@ -44,12 +44,16 @@ export function ClickToComponent({ editor = 'vscode' }) {
         const url = `${editor}://file/${path}`
 
         event.preventDefault()
-        window.open(url)
+        if (onOpenFile) {
+          onOpenFile(path)
+        } else {
+          window.open(url)
+        }
 
         setState(State.IDLE)
       }
     },
-    [editor, state, target]
+    [editor, onOpenFile, state, target]
   )
 
   const onClose = React.useCallback(

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -1,10 +1,12 @@
+import { Source } from 'react-reconciler'
+
 export { ClickToComponent } from './src/ClickToComponent'
 
 export type Editor = 'vscode' | 'vscode-insiders'
 
 export type ClickToComponentProps = {
   editor?: Editor
-  onOpenFile?: (path: string) => void
+  onOpenComponent?: (source: Source) => void
 }
 
 export type Coords = [MouseEvent['pageX'], MouseEvent['pageY']]

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -4,6 +4,7 @@ export type Editor = 'vscode' | 'vscode-insiders'
 
 export type ClickToComponentProps = {
   editor?: Editor
+  onOpenFile?: (path: string) => void
 }
 
 export type Coords = [MouseEvent['pageX'], MouseEvent['pageY']]


### PR DESCRIPTION
This PR adds support for `onOpenFile` callback. When set, it will be called instead of opening the file with the default editor. This change will enable the support for the long tail of editors and will allow other products to build on top of `click-to-component`.

## Usage

```
<ClickToComponent onOpenComponent={(source) => alert(source.fileName)} />
```

Fixes https://github.com/ericclemmons/click-to-component/issues/28