### PR TITLE
Show menu only on Option+Right-click

### DIFF
--- a/.changeset/soft-adults-fail.md
+++ b/.changeset/soft-adults-fail.md
@@ -1,0 +1,5 @@
+---
+"click-to-react-component": patch
+---
+
+Show menu only on Option+Right-click

--- a/packages/click-to-react-component/src/ContextMenu.js
+++ b/packages/click-to-react-component/src/ContextMenu.js
@@ -113,6 +113,10 @@ export const ContextMenu = React.forwardRef(
         /** @type {MouseEvent} */
         e
       ) {
+        if (!e.altKey) {
+          return
+        }
+
         e.preventDefault()
         mergedReferenceRef({
           getBoundingClientRect() {


### PR DESCRIPTION
The README states `Option+Right-click` is used to show the menu but even the regular `Right-click` works.