### PR TITLE
Give context menu highest z-index to try and float it above other elements

### DIFF
--- a/packages/click-to-react-component/src/ContextMenu.js
+++ b/packages/click-to-react-component/src/ContextMenu.js
@@ -183,6 +183,7 @@ export const ContextMenu = React.forwardRef(
         [data-click-to-component-contextmenu],
         [data-click-to-component-contextmenu] * {
           box-sizing: border-box !important;
+          z-index: 2147483647;
         }
 
         [data-click-to-component-contextmenu] {


### PR DESCRIPTION
Noticed the context menu getting lost below elements with z-index > 0. Giving the highest z-index value to the context menu to give it a chance of being on above other elements.