### PR TITLE
Set floating-ui to max z-index

### DIFF
--- a/packages/click-to-react-component/src/ContextMenu.js
+++ b/packages/click-to-react-component/src/ContextMenu.js
@@ -183,6 +183,7 @@ export const ContextMenu = React.forwardRef(
         [data-click-to-component-contextmenu],
         [data-click-to-component-contextmenu] * {
           box-sizing: border-box !important;
+          z-index: 2147483647;
         }
 
         [data-click-to-component-contextmenu] {

--- a/packages/click-to-react-component/src/ContextMenu.js
+++ b/packages/click-to-react-component/src/ContextMenu.js
@@ -180,10 +180,10 @@ export const ContextMenu = React.forwardRef(
 
     return html`
       <style key="click-to-component-contextmenu-style">
-        [data-click-to-component] * {
+        #floating-ui-root > div {
           z-index: 2147483647;
         }
-        
+
         [data-click-to-component-contextmenu],
         [data-click-to-component-contextmenu] * {
           box-sizing: border-box !important;

--- a/packages/click-to-react-component/src/ContextMenu.js
+++ b/packages/click-to-react-component/src/ContextMenu.js
@@ -180,10 +180,13 @@ export const ContextMenu = React.forwardRef(
 
     return html`
       <style key="click-to-component-contextmenu-style">
+        [data-click-to-component] * {
+          z-index: 2147483647;
+        }
+        
         [data-click-to-component-contextmenu],
         [data-click-to-component-contextmenu] * {
           box-sizing: border-box !important;
-          z-index: 2147483647;
         }
 
         [data-click-to-component-contextmenu] {


### PR DESCRIPTION
This seems to pass my smoke tests.

The menu is wrapped in a div which needs to get the z-index in order for the menu to display above everything, but not interfere with existing elements with z-indexes.