### PR TITLE
Fix `data-click-to-component` attribute staying on body indefinitely

### DIFF
--- a/.changeset/mighty-wombats-move.md
+++ b/.changeset/mighty-wombats-move.md
@@ -1,0 +1,5 @@
+---
+'click-to-react-component': patch
+---
+
+Fixes `data-click-to-component` attribute staying on body indefinitely

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -152,7 +152,12 @@ export function ClickToComponent({ editor = 'vscode' }) {
       }
 
       if (state === State.IDLE) {
-        delete window.document.body.dataset.clickToComponentTarget
+        delete window.document.body.dataset.clickToComponent
+        
+        if (target) {
+          delete target.dataset.clickToComponentTarget
+        }
+        
         return
       }
 


### PR DESCRIPTION
That was causing the styles `pointer-events: auto !important;` to get applied to all body descendants indefinitely after ClickToComponent hover state was triggered.