### PR TITLE
Fix path to ClickToComponent on TS definition file

### DIFF
--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -1,4 +1,4 @@
-export { ClickToComponent } from './src/ClickToComponent'
+export { ClickToComponent } from './ClickToComponent'
 
 export type Editor = 'vscode' | 'vscode-insiders'
 


### PR DESCRIPTION
`types.d.ts` is located inside `src` already.

Fixes #40.