### PR TITLE
Improve outline style

### DIFF
--- a/.changeset/beige-paws-warn.md
+++ b/.changeset/beige-paws-warn.md
@@ -1,0 +1,7 @@
+---
+"click-to-react-component": patch
+---
+
+Change outline style to accessible colors:
+
+> <img width="751" alt="Screen Shot 2022-06-11 at 11 51 58 AM" src="https://user-images.githubusercontent.com/15182/173197193-dd831818-1fc9-403f-8f0b-9b5bae55f8db.png">

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -200,10 +200,8 @@ export function ClickToComponent({ editor = 'vscode' }) {
         cursor: var(--click-to-component-cursor, context-menu) !important;
         outline: var(
           --click-to-component-outline,
-          2px solid lightgreen
+          -webkit-focus-ring-color auto 1px
         ) !important;
-        outline-offset: -2px;
-        outline-style: inset;
       }
     </style>
 

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -198,6 +198,7 @@ export function ClickToComponent({ editor = 'vscode' }) {
 
       [data-click-to-component-target] {
         cursor: var(--click-to-component-cursor, context-menu) !important;
+        outline: auto 1px;
         outline: var(
           --click-to-component-outline,
           -webkit-focus-ring-color auto 1px


### PR DESCRIPTION
## Pitfall
The previously set outline color will be difficult to see under the similar background color。

## Solution
- Set outline color with `-webkit-focus-ring-color` will follow the system ambient color, this color value is compatible with most browsers and it could fallback to inheriting `color` even if this value not compatible with the browser.
- Set outline style with `auto` will let the appearance take over by the browser, so it will always visible and comply with [W3C WAI](https://www.w3.org/WAI/standards-guidelines) specification.