### PR TITLE
Prevent bundle from being included in prod build

### DIFF
--- a/.changeset/honest-dingos-roll.md
+++ b/.changeset/honest-dingos-roll.md
@@ -1,0 +1,5 @@
+---
+'click-to-react-component': patch
+---
+
+Prevent bundle from being included in prod build

--- a/packages/click-to-react-component/package.json
+++ b/packages/click-to-react-component/package.json
@@ -44,5 +44,6 @@
     "@types/react-reconciler": "^0.26.6",
     "eslint": "^8.0.0",
     "eslint-config-react-app": "^7.0.1"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Just saw that the package contents were included in production because the package is not marked as side-effect-free. I added the flag so that rollup and webpack remove the package contets from production.