### PR TITLE
Fix #40 – Cannot find module './src/ClickToComponent' or its corresponding type declarations.

### DIFF
--- a/.changeset/lovely-deers-mate.md
+++ b/.changeset/lovely-deers-mate.md
@@ -1,0 +1,6 @@
+---
+"next": patch
+"click-to-react-component": patch
+---
+
+Fix "Cannot find module './src/ClickToComponent' or its corresponding type declarations."

--- a/apps/next/tsconfig.json
+++ b/apps/next/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -1,4 +1,4 @@
-export { ClickToComponent } from './src/ClickToComponent'
+export { ClickToComponent } from './ClickToComponent'
 
 export type Editor = 'vscode' | 'vscode-insiders'
 


### PR DESCRIPTION
Basically reproduced #40 locally described by @andrewgreenh.

A good show of why there are examples in this repo – any issues should be reproducible within the project & fixable, too!