### PR TITLE
Improve UX, prevent flicker, jump into editor seamlessly

### DIFF
--- a/.changeset/beige-paws-warn.md
+++ b/.changeset/beige-paws-warn.md
@@ -1,0 +1,7 @@
+---
+"click-to-react-component": patch
+---
+
+Change outline style to accessible colors:
+
+> <img width="751" alt="Screen Shot 2022-06-11 at 11 51 58 AM" src="https://user-images.githubusercontent.com/15182/173197193-dd831818-1fc9-403f-8f0b-9b5bae55f8db.png">

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -44,7 +44,7 @@ export function ClickToComponent({ editor = 'vscode' }) {
         const url = `${editor}://file/${path}`
 
         event.preventDefault()
-        window.open(url)
+        window.location.assign(url)
 
         setState(State.IDLE)
       }
@@ -56,7 +56,7 @@ export function ClickToComponent({ editor = 'vscode' }) {
     function handleClose(returnValue) {
       if (returnValue) {
         const url = `${editor}://file/${returnValue}`
-        window.open(url)
+        window.location.assign(url)
       }
 
       setState(State.IDLE)

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -200,10 +200,8 @@ export function ClickToComponent({ editor = 'vscode' }) {
         cursor: var(--click-to-component-cursor, context-menu) !important;
         outline: var(
           --click-to-component-outline,
-          2px solid lightgreen
+          -webkit-focus-ring-color auto 1px
         ) !important;
-        outline-offset: -2px;
-        outline-style: inset;
       }
     </style>
 

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -198,6 +198,7 @@ export function ClickToComponent({ editor = 'vscode' }) {
 
       [data-click-to-component-target] {
         cursor: var(--click-to-component-cursor, context-menu) !important;
+        outline: auto 1px;
         outline: var(
           --click-to-component-outline,
           -webkit-focus-ring-color auto 1px


### PR DESCRIPTION
# Problem
When `option` + `click` to jump into editor, it will open a new tab to require permission, or flicker on current page if it has already got permission. And that flicker experience is really bad, so this PR come to fix.

# Before 😫
<img src="https://user-images.githubusercontent.com/74389358/173544710-a46b998b-2b35-4e77-a7ca-1e75051daabe.gif" width="300" />

<img src="https://user-images.githubusercontent.com/74389358/173544695-be04c07f-a696-4fe7-9691-330dc5336ccd.gif" width="300" />

# After 🤩
<img src="https://user-images.githubusercontent.com/74389358/173545308-07fb8772-cf55-440a-849f-1d7c3a7fbcdb.gif" width="300" />
<img src="https://user-images.githubusercontent.com/74389358/173545471-58cf4568-bd8f-497f-8a36-6a294f022e4b.gif" width="300" />

