### PR TITLE
pathModifier added as a prop

### DIFF
--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -20,7 +20,7 @@ export const State = /** @type {const} */ ({
 /**
  * @param {Props} props
  */
-export function ClickToComponent({ editor = 'vscode' }) {
+export function ClickToComponent({ editor = 'vscode', pathModifier }) {
   const [state, setState] = React.useState(
     /** @type {State[keyof State]} */
     (State.IDLE)
@@ -41,7 +41,13 @@ export function ClickToComponent({ editor = 'vscode' }) {
       if (state === State.HOVER && target instanceof HTMLElement) {
         const source = getSourceForElement(target)
         const path = getPathToSource(source)
-        const url = `${editor}://file/${path}`
+
+        let modifiedPath = path
+        if (pathModifier) {
+          modifiedPath = pathModifier(path)
+        }
+
+        const url = `${editor}://file/${modifiedPath}`
 
         event.preventDefault()
         window.location.assign(url)
@@ -153,11 +159,11 @@ export function ClickToComponent({ editor = 'vscode' }) {
 
       if (state === State.IDLE) {
         delete window.document.body.dataset.clickToComponent
-        
+
         if (target) {
           delete target.dataset.clickToComponentTarget
         }
-        
+
         return
       }
 

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -3,7 +3,8 @@ export { ClickToComponent } from './ClickToComponent'
 export type Editor = 'vscode' | 'vscode-insiders'
 
 export type ClickToComponentProps = {
-  editor?: Editor
+  editor?: Editor,
+  pathModifier?: Function
 }
 
 export type Coords = [MouseEvent['pageX'], MouseEvent['pageY']]


### PR DESCRIPTION
This PR is respect to the issue #58. Added pathModifier function as a prop which can be used to change/modify the path of the detected component which solves the "Path not found" error on apps running in docker containers.