### PR TITLE
Add Remix/ESBuild support by checking the _debugOwner._debugSource

### DIFF
--- a/.changeset/witty-bobcats-serve.md
+++ b/.changeset/witty-bobcats-serve.md
@@ -1,0 +1,5 @@
+---
+'click-to-react-component': minor
+---
+
+Add remix/esbuild support by checking the \_debugOwner.\_debugSource

--- a/apps/remix/app/session.server.ts
+++ b/apps/remix/app/session.server.ts
@@ -10,7 +10,6 @@ export const sessionStorage = createCookieSessionStorage({
   cookie: {
     name: "__session",
     httpOnly: true,
-    maxAge: 0,
     path: "/",
     sameSite: "lax",
     secrets: [process.env.SESSION_SECRET],
@@ -25,13 +24,15 @@ export async function getSession(request: Request) {
   return sessionStorage.getSession(cookie);
 }
 
-export async function getUserId(request: Request): Promise<string | undefined> {
+export async function getUserId(
+  request: Request
+): Promise<User["id"] | undefined> {
   const session = await getSession(request);
   const userId = session.get(USER_SESSION_KEY);
   return userId;
 }
 
-export async function getUser(request: Request): Promise<null | User> {
+export async function getUser(request: Request) {
   const userId = await getUserId(request);
   if (userId === undefined) return null;
 
@@ -44,7 +45,7 @@ export async function getUser(request: Request): Promise<null | User> {
 export async function requireUserId(
   request: Request,
   redirectTo: string = new URL(request.url).pathname
-): Promise<string> {
+) {
   const userId = await getUserId(request);
   if (!userId) {
     const searchParams = new URLSearchParams([["redirectTo", redirectTo]]);

--- a/apps/remix/app/tailwind.css
+++ b/apps/remix/app/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/remix/postcss.config.js
+++ b/apps/remix/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/remix/tailwind.config.js
+++ b/apps/remix/tailwind.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  content: ["./app/**/*.{ts,tsx,jsx,js}"],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};

--- a/apps/remix/tailwind.config.ts
+++ b/apps/remix/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./app/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -147,6 +147,19 @@ export function ClickToComponent({ editor = 'vscode', pathModifier }) {
     [state]
   )
 
+  const onBlur = React.useCallback(
+    function handleBlur() {
+      switch (state) {
+        case State.HOVER:
+          setState(State.IDLE)
+          break
+
+        default:
+      }
+    },
+    [state]
+  )
+
   React.useEffect(
     function toggleIndicator() {
       for (const element of Array.from(
@@ -159,11 +172,9 @@ export function ClickToComponent({ editor = 'vscode', pathModifier }) {
 
       if (state === State.IDLE) {
         delete window.document.body.dataset.clickToComponent
-
         if (target) {
           delete target.dataset.clickToComponentTarget
         }
-
         return
       }
 
@@ -182,6 +193,7 @@ export function ClickToComponent({ editor = 'vscode', pathModifier }) {
       window.addEventListener('keydown', onKeyDown)
       window.addEventListener('keyup', onKeyUp)
       window.addEventListener('mousemove', onMouseMove)
+      window.addEventListener('blur', onBlur)
 
       return function removeEventListenersFromWindow() {
         window.removeEventListener('click', onClick, { capture: true })
@@ -191,9 +203,10 @@ export function ClickToComponent({ editor = 'vscode', pathModifier }) {
         window.removeEventListener('keydown', onKeyDown)
         window.removeEventListener('keyup', onKeyUp)
         window.removeEventListener('mousemove', onMouseMove)
+        window.removeEventListener('blur', onBlur)
       }
     },
-    [onClick, onContextMenu, onKeyDown, onKeyUp, onMouseMove]
+    [onClick, onContextMenu, onKeyDown, onKeyUp, onMouseMove, onBlur]
   )
 
   return html`

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -40,14 +40,9 @@ export function ClickToComponent({ editor = 'vscode', pathModifier }) {
     ) {
       if (state === State.HOVER && target instanceof HTMLElement) {
         const source = getSourceForElement(target)
-        const path = getPathToSource(source)
+        const path = getPathToSource(source, pathModifier)
 
-        let modifiedPath = path
-        if (pathModifier) {
-          modifiedPath = pathModifier(path)
-        }
-
-        const url = `${editor}://file/${modifiedPath}`
+        const url = `${editor}://file/${path}`
 
         event.preventDefault()
         window.location.assign(url)
@@ -229,6 +224,7 @@ export function ClickToComponent({ editor = 'vscode', pathModifier }) {
       ${html`<${ContextMenu}
         key="click-to-component-contextmenu"
         onClose=${onClose}
+        pathModifier=${pathModifier}
       />`}
     </${FloatingPortal}
   `

--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -20,7 +20,7 @@ export const State = /** @type {const} */ ({
 /**
  * @param {Props} props
  */
-export function ClickToComponent({ editor = 'vscode' }) {
+export function ClickToComponent({ editor = 'vscode', pathModifier }) {
   const [state, setState] = React.useState(
     /** @type {State[keyof State]} */
     (State.IDLE)
@@ -41,7 +41,13 @@ export function ClickToComponent({ editor = 'vscode' }) {
       if (state === State.HOVER && target instanceof HTMLElement) {
         const source = getSourceForElement(target)
         const path = getPathToSource(source)
-        const url = `${editor}://file/${path}`
+
+        let modifiedPath = path
+        if (pathModifier) {
+          modifiedPath = pathModifier(path)
+        }
+
+        const url = `${editor}://file/${modifiedPath}`
 
         event.preventDefault()
         window.location.assign(url)
@@ -141,19 +147,6 @@ export function ClickToComponent({ editor = 'vscode' }) {
     [state]
   )
 
-  const onBlur = React.useCallback(
-    function handleBlur() {
-      switch (state) {
-        case State.HOVER:
-          setState(State.IDLE)
-          break
-
-        default:
-      }
-    },
-    [state]
-  )
-
   React.useEffect(
     function toggleIndicator() {
       for (const element of Array.from(
@@ -166,11 +159,11 @@ export function ClickToComponent({ editor = 'vscode' }) {
 
       if (state === State.IDLE) {
         delete window.document.body.dataset.clickToComponent
-        
+
         if (target) {
           delete target.dataset.clickToComponentTarget
         }
-        
+
         return
       }
 
@@ -189,7 +182,6 @@ export function ClickToComponent({ editor = 'vscode' }) {
       window.addEventListener('keydown', onKeyDown)
       window.addEventListener('keyup', onKeyUp)
       window.addEventListener('mousemove', onMouseMove)
-      window.addEventListener('blur', onBlur)
 
       return function removeEventListenersFromWindow() {
         window.removeEventListener('click', onClick, { capture: true })
@@ -199,10 +191,9 @@ export function ClickToComponent({ editor = 'vscode' }) {
         window.removeEventListener('keydown', onKeyDown)
         window.removeEventListener('keyup', onKeyUp)
         window.removeEventListener('mousemove', onMouseMove)
-        window.removeEventListener('blur', onBlur)
       }
     },
-    [onClick, onContextMenu, onKeyDown, onKeyUp, onMouseMove, onBlur]
+    [onClick, onContextMenu, onKeyDown, onKeyUp, onMouseMove]
   )
 
   return html`

--- a/packages/click-to-react-component/src/ContextMenu.js
+++ b/packages/click-to-react-component/src/ContextMenu.js
@@ -35,7 +35,7 @@ export const ContextMenu = React.forwardRef(
     props,
     ref
   ) => {
-    const { onClose } = props
+    const { onClose, pathModifier } = props
 
     const [target, setTarget] = React.useState(
       /** @type {HTMLElement | null} */
@@ -327,7 +327,7 @@ export const ContextMenu = React.forwardRef(
                 ${instances.map((instance, i) => {
                   const name = getDisplayNameForInstance(instance)
                   const source = getSourceForInstance(instance)
-                  const path = getPathToSource(source)
+                  const path = getPathToSource(source, pathModifier)
                   const props = getPropsForInstance(instance)
 
                   return html`

--- a/packages/click-to-react-component/src/getPathToSource.js
+++ b/packages/click-to-react-component/src/getPathToSource.js
@@ -14,9 +14,5 @@ export function getPathToSource(source) {
     lineNumber = 1,
   } = source;
 
-  // some transpilers store fileName as a relative path in that case user should provide the project absolute path manually.
-  const projectRoot = window.__click_to_react_component_project_path || '';
-  const filePath = `${projectRoot.replace(/\/$/, '')}/${fileName}`;
-
-  return `${filePath}:${lineNumber}:${columnNumber}`;
+  return `${fileName}:${lineNumber}:${columnNumber}`;
 }

--- a/packages/click-to-react-component/src/getPathToSource.js
+++ b/packages/click-to-react-component/src/getPathToSource.js
@@ -12,7 +12,11 @@ export function getPathToSource(source) {
     columnNumber = 1,
     fileName,
     lineNumber = 1,
-  } = source
+  } = source;
 
-  return `${fileName}:${lineNumber}:${columnNumber}`
+  // some transpilers store fileName as a relative path in that case user should provide the project absolute path manually.
+  const projectRoot = window.__click_to_react_component_project_path || '';
+  const filePath = `${projectRoot.replace(/\/$/, '')}/${fileName}`;
+
+  return `${filePath}:${lineNumber}:${columnNumber}`;
 }

--- a/packages/click-to-react-component/src/getPathToSource.js
+++ b/packages/click-to-react-component/src/getPathToSource.js
@@ -1,11 +1,13 @@
 /**
  * @typedef {import('react-reconciler').Source} Source
+ * @typedef {import('./types').PathModifier} PathModifier
  */
 
 /**
  * @param {Source} source
+ * @param {PathModifier} pathModifier
  */
-export function getPathToSource(source) {
+export function getPathToSource(source, pathModifier) {
   const {
     // It _does_ exist!
     // @ts-ignore Property 'columnNumber' does not exist on type 'Source'.ts(2339)
@@ -14,5 +16,10 @@ export function getPathToSource(source) {
     lineNumber = 1,
   } = source
 
-  return `${fileName}:${lineNumber}:${columnNumber}`
+  let path = `${fileName}:${lineNumber}:${columnNumber}`
+  if (pathModifier) {
+    path = pathModifier(path)
+  }
+
+  return path
 }

--- a/packages/click-to-react-component/src/getPathToSource.js
+++ b/packages/click-to-react-component/src/getPathToSource.js
@@ -12,7 +12,7 @@ export function getPathToSource(source) {
     columnNumber = 1,
     fileName,
     lineNumber = 1,
-  } = source;
+  } = source
 
-  return `${fileName}:${lineNumber}:${columnNumber}`;
+  return `${fileName}:${lineNumber}:${columnNumber}`
 }

--- a/packages/click-to-react-component/src/getSourceForInstance.js
+++ b/packages/click-to-react-component/src/getSourceForInstance.js
@@ -8,9 +8,9 @@
  */
 export function getSourceForInstance({ _debugSource, _debugOwner }) {
   // source is sometimes stored on _debugOwner
-  const source = _debugSource || (_debugOwner && _debugOwner._debugSource);
+  const source = _debugSource || (_debugOwner && _debugOwner._debugSource)
 
-  if (!source) return;
+  if (!source) return
 
   const {
     // It _does_ exist!
@@ -18,7 +18,7 @@ export function getSourceForInstance({ _debugSource, _debugOwner }) {
     columnNumber = 1,
     fileName,
     lineNumber = 1,
-  } = source;
+  } = source
 
-  return { columnNumber, fileName, lineNumber };
+  return { columnNumber, fileName, lineNumber }
 }

--- a/packages/click-to-react-component/src/getSourceForInstance.js
+++ b/packages/click-to-react-component/src/getSourceForInstance.js
@@ -6,8 +6,11 @@
 /**
  * @param {Fiber} instance
  */
-export function getSourceForInstance({ _debugSource }) {
-  if (!_debugSource) return
+export function getSourceForInstance({ _debugSource, _debugOwner }) {
+  // source is sometimes stored on _debugOwner
+  const source = _debugSource || (_debugOwner && _debugOwner._debugSource);
+
+  if (!source) return;
 
   const {
     // It _does_ exist!
@@ -15,7 +18,7 @@ export function getSourceForInstance({ _debugSource }) {
     columnNumber = 1,
     fileName,
     lineNumber = 1,
-  } = _debugSource
+  } = source;
 
-  return { columnNumber, fileName, lineNumber }
+  return { columnNumber, fileName, lineNumber };
 }

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -14,9 +14,3 @@ export type Target = HTMLElement
 export type ContextMenuProps = {
   onClose?: () => void
 }
-
-declare global {
-  interface Window {
-    __click_to_react_component_project_path: string;
-  }
-}

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -2,9 +2,11 @@ export { ClickToComponent } from './ClickToComponent'
 
 export type Editor = 'vscode' | 'vscode-insiders'
 
+export type PathModifier = (path: string) => string;
+
 export type ClickToComponentProps = {
-  editor?: Editor,
-  pathModifier?: (path: string) => string;
+  editor?: Editor;
+  pathModifier?: PathModifier;
 }
 
 export type Coords = [MouseEvent['pageX'], MouseEvent['pageY']]
@@ -12,5 +14,6 @@ export type Coords = [MouseEvent['pageX'], MouseEvent['pageY']]
 export type Target = HTMLElement
 
 export type ContextMenuProps = {
-  onClose?: () => void
+  onClose?: () => void;
+  pathModifier?: PathModifier;
 }

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -13,3 +13,9 @@ export type Target = HTMLElement
 export type ContextMenuProps = {
   onClose?: () => void
 }
+
+declare global {
+  interface Window {
+    __click_to_react_component_project_path: string;
+  }
+}

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -3,7 +3,8 @@ export { ClickToComponent } from './ClickToComponent'
 export type Editor = 'vscode' | 'vscode-insiders'
 
 export type ClickToComponentProps = {
-  editor?: Editor
+  editor?: Editor,
+  pathModifier?: (path: string) => string;
 }
 
 export type Coords = [MouseEvent['pageX'], MouseEvent['pageY']]


### PR DESCRIPTION
As Remix/ESBuild `_debugSource` filepaths are relative I had to also add [GaitanK](https://github.com/GaitanK)'s code in order to make path absolute in my Remix app.  

ESBuild has added _debugSource for a long time now https://github.com/evanw/esbuild/issues/2318 but looks like at least in React 18 we need to read it from somewhere else.  

@ericclemmons, happy to have your feedback on this.
