### PR TITLE
Show outline in Firefox

### DIFF
--- a/packages/click-to-react-component/src/ClickToComponent.js
+++ b/packages/click-to-react-component/src/ClickToComponent.js
@@ -220,10 +220,24 @@ export function ClickToComponent({ editor = 'vscode', pathModifier }) {
       [data-click-to-component-target] {
         cursor: var(--click-to-component-cursor, context-menu) !important;
         outline: auto 1px;
-        outline: var(
-          --click-to-component-outline,
-          -webkit-focus-ring-color auto 1px
-        ) !important;
+      }
+
+      @supports (outline-color: Highlight) {
+        [data-click-to-component-target] {
+          outline: var(
+            --click-to-component-outline,
+            Highlight auto 1px
+          ) !important;
+        }
+      }
+
+      @supports (outline-color: -webkit-focus-ring-color) {
+        [data-click-to-component-target] {
+          outline: var(
+            --click-to-component-outline,
+            -webkit-focus-ring-color auto 1px
+          ) !important;
+        }
       }
     </style>
 


### PR DESCRIPTION
See: [Copy The Browser's Native Focus Styles | CSS-Tricks](https://css-tricks.com/copy-the-browsers-native-focus-styles/)

I tried the code below, it does not work. So I decide to use `@supports` to detect.

```css
[data-click-to-component-target] {
  cursor: var(--click-to-component-cursor, context-menu) !important;
  outline: auto 1px;
  outline: var(
      --click-to-component-outline,
      -webkit-focus-ring-color auto 1px,
      Highlight auto 1px
    ) !important;
  }
}
```