### PR TITLE
feat: support cursor editor

### DIFF
--- a/.changeset/many-lies-fold.md
+++ b/.changeset/many-lies-fold.md
@@ -1,0 +1,5 @@
+---
+"click-to-react-component": patch
+---
+
+feat: support cursor

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .turbo
+.idea
 
 # Logs
 logs

--- a/packages/click-to-react-component/README.md
+++ b/packages/click-to-react-component/README.md
@@ -18,7 +18,7 @@
   [Create React App](https://create-react-app.dev/),
   & [Vite](https://github.com/vitejs/vite/tree/main/packages/plugin-react)
   that use [@babel/plugin-transform-react-jsx-source](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-jsx-source)
-- Supports `vscode` & `vscode-insiders`' [URL handling](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls)
+- Supports `vscode` & `vscode-insiders` & `cursor` [URL handling](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls)
 - Automatically **tree-shaken** from `production` builds
 - Keyboard navigation in context menu (e.g. <kbd>←</kbd>, <kbd>→</kbd>, <kbd>⏎</kbd>)
 - More context & faster than using React DevTools:

--- a/packages/click-to-react-component/src/types.d.ts
+++ b/packages/click-to-react-component/src/types.d.ts
@@ -1,6 +1,6 @@
-export { ClickToComponent } from './ClickToComponent'
+export { ClickToComponent } from './ClickToComponent';
 
-export type Editor = 'vscode' | 'vscode-insiders'
+export type Editor = 'vscode' | 'vscode-insiders' | 'cursor';
 
 export type PathModifier = (path: string) => string;
 


### PR DESCRIPTION
Cursor is a fork of VS Code.

The URL scheme rules are the same.